### PR TITLE
Pass publication_state as a string to the VideosRequestParameters

### DIFF
--- a/lib/DataProvider/VideoManagerProSearch.php
+++ b/lib/DataProvider/VideoManagerProSearch.php
@@ -95,24 +95,13 @@ class VideoManagerProSearch implements DataProviderInterface
             'order_property' => 'setOrderProperty',
             'offset' => 'setOffset',
             'id' => 'setVideoId',
+            'publication_state' => 'setPublicationState',
         ];
 
         foreach ($queryMethods as $key => $method) {
             if (isset($options[$key])) {
                 $parameters->$method($options[$key]);
             }
-        }
-
-        if (isset($options['publication_state'])) {
-            switch ($options['publication_state']) {
-                case 'published':
-                    $parameters->setPublicationState(true);
-                    break;
-                case 'not_published':
-                    $parameters->setPublicationState(false);
-                    break;
-                //case 'all': do nothing
-            };
         }
 
         return $parameters;


### PR DESCRIPTION
PublicationState property in VideosRequestParameters is not supposed to be a boolean, but a string, containing one of the following values:

- published
- not_published
- all